### PR TITLE
Fix calls to constructor of parent class

### DIFF
--- a/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
+++ b/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
@@ -9,7 +9,7 @@ class KotlinLangAdapter implements LangAdapter {
 
   @Override
   public void beginAssocClass(Append writer, String shortName, String origShortName) {
-    writer.append("class Q%s<R>(name: String, root: R) : TQAssocBean<%s,R>(name, root) {", shortName, origShortName).eol();
+    writer.append("class Q%s<R> : TQAssocBean<%s,R> {", shortName, origShortName).eol();
   }
 
   @Override
@@ -27,8 +27,9 @@ class KotlinLangAdapter implements LangAdapter {
   @Override
   public void assocBeanConstructor(Append writer, String shortName) {
 
-    // additionally constructor with prefix parameter
-    writer.append("  constructor(name: String, root: R, prefix: String) : super(name, root, prefix) {}").eol();
+    writer.append("  constructor(name: String, root: R) : super(name, root)").eol();
+    writer.eol();
+    writer.append("  constructor(name: String, root: R, prefix: String) : super(name, root, prefix)").eol();
   }
 
   @Override


### PR DESCRIPTION
The new secondary constructor for `QAssocXyz<R>` classes does not call the primary constructor:
```
> Task :compileKotlin
e: /home/user/project/build/generated/source/kaptKotlin/main/com/example/model/query/assoc/QAssocFoobar.kt: (45, 56): Primary constructor call expected
```

By removing the primary constructor and implementing both constructors as secondary constructors, this issue can be resolved. In case this issue is caused by my setup, please feel free to close this PR.