### PR TITLE
ENH: Allow ScalarTypes to be used in querybeans

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.xml]
+max_line_length = 9999999

--- a/src/main/java/io/ebean/querybean/generator/PropertyTypeScalar.java
+++ b/src/main/java/io/ebean/querybean/generator/PropertyTypeScalar.java
@@ -1,0 +1,48 @@
+package io.ebean.querybean.generator;
+
+import java.util.Set;
+
+/**
+ * Property type for associated beans (OneToMany, ManyToOne etc).
+ */
+class PropertyTypeScalar extends PropertyType {
+
+  /**
+   * The package name for this associated query bean.
+   */
+  private final String assocPackage;
+  private final String attributeSimpleName;
+
+  /**
+   * Construct given the associated bean type name and package.
+   *
+   * @param attributeClass   the type in the database bean that will be serialized via ScalarType
+   */
+  PropertyTypeScalar(String attributeClass) {
+    super("PScalar");
+    int split = attributeClass.lastIndexOf('.');
+    this.assocPackage = attributeClass.substring(0, split);
+    this.attributeSimpleName = attributeClass.substring(split + 1);
+  }
+
+  @Override
+  String getTypeDefn(String shortName, boolean assoc) {
+    if (assoc) {
+      // PScalarType<R, PhoneNumber>
+      return "PScalar<R, " + attributeSimpleName + ">";
+    } else {
+      // PScalarType<QCustomer, PhoneNumber>
+      return "PScalar<Q" + shortName + ", " + attributeSimpleName + ">";
+    }
+  }
+
+  /**
+   * All required imports to the allImports set.
+   */
+  @Override
+  void addImports(Set<String> allImports) {
+    super.addImports(allImports);
+    allImports.add(assocPackage + "." + attributeSimpleName);
+  }
+
+}

--- a/src/main/java/io/ebean/querybean/generator/PropertyTypeScalarComparable.java
+++ b/src/main/java/io/ebean/querybean/generator/PropertyTypeScalarComparable.java
@@ -1,0 +1,48 @@
+package io.ebean.querybean.generator;
+
+import java.util.Set;
+
+/**
+ * Property type for associated beans (OneToMany, ManyToOne etc).
+ */
+class PropertyTypeScalarComparable extends PropertyType {
+
+  /**
+   * The package name for this associated query bean.
+   */
+  private final String assocPackage;
+  private final String attributeSimpleName;
+
+  /**
+   * Construct given the associated bean type name and package.
+   *
+   * @param attributeClass   the type in the database bean that will be serialized via ScalarType
+   */
+  PropertyTypeScalarComparable(String attributeClass) {
+    super("PScalarComparable");
+    int split = attributeClass.lastIndexOf('.');
+    this.assocPackage = attributeClass.substring(0, split);
+    this.attributeSimpleName = attributeClass.substring(split + 1);
+  }
+
+  @Override
+  String getTypeDefn(String shortName, boolean assoc) {
+    if (assoc) {
+      // PScalarType<R, PhoneNumber>
+      return "PScalarComparable<R, " + attributeSimpleName + ">";
+    } else {
+      // PScalarType<QCustomer, PhoneNumber>
+      return "PScalarComparable<Q" + shortName + ", " + attributeSimpleName + ">";
+    }
+  }
+
+  /**
+   * All required imports to the allImports set.
+   */
+  @Override
+  void addImports(Set<String> allImports) {
+    super.addImports(allImports);
+    allImports.add(assocPackage + "." + attributeSimpleName);
+  }
+
+}


### PR DESCRIPTION
Solution B for https://github.com/ebean-orm/ebean-querybean/issues/74

This just assumes that every field that is supposed to be serialized into the database, can also be queried.

In addition, those fields whose type implements Comparable will also be assumed to be comparable by the database.